### PR TITLE
Initial API Implementation

### DIFF
--- a/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
+++ b/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
@@ -2,19 +2,23 @@ package harmonised.pmmo.api;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import harmonised.pmmo.config.JType;
 import harmonised.pmmo.util.XP;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
 public class PredicateRegistry {
 	
 	private static Map<String, Predicate<PlayerEntity>> reqPredicates = new HashMap<>();
+	private static Map<String, BiPredicate<PlayerEntity, TileEntity>> reqBreakPredicates = new HashMap<>();
 	
 	/** registers a predicate to be used in determining if a given player is permitted
-	 * to perform a particular action.  The ResouceLocation and JType parameters are 
+	 * to perform a particular action. [Except for break action.  see registerBreakPredicate.
+	 * The ResouceLocation and JType parameters are 
 	 * conditions for when this check should be applied and are used by PMMO to know
 	 * which predicates apply in which contexts.  The predicate itself links to the 
 	 * compat mod's logic which handles the external behavior.
@@ -32,6 +36,25 @@ public class PredicateRegistry {
 		XP.LOGGER.info("Predicate Registered: "+condition);
 	}
 	
+	/** registers a predicate to be used in determining if a given player is permitted
+	 * to break a block.  The ResouceLocation and JType parameters are 
+	 * conditions for when this check should be applied and are used by PMMO to know
+	 * which predicates apply in which contexts.  The predicate itself links to the 
+	 * compat mod's logic which handles the external behavior.
+	 * 
+	 * @param res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param pred what executes to determine if player is permitted to perform the action
+	 */
+	public static void registerBreakPredicate(ResourceLocation res, JType jType, BiPredicate<PlayerEntity, TileEntity> pred) 
+	{
+		String condition = jType.toString()+";"+res.toString();
+		if ( pred == null ) 
+			return;
+		reqBreakPredicates.put( condition, pred );
+		XP.LOGGER.info("Predicate Registered: "+condition);
+	}
+	
 	/**this is an internal method to check if a predicate exists for the given conditions
 	 * 
 	 * @param res res the block, item, or entity registrykey
@@ -40,6 +63,8 @@ public class PredicateRegistry {
 	 */
 	public static boolean predicateExists(ResourceLocation res, JType jType) 
 	{
+		if (jType.equals(JType.REQ_BREAK))
+			return reqBreakPredicates.containsKey( jType.toString()+";"+res.toString() );
 		return reqPredicates.containsKey( jType.toString()+";"+res.toString() );
 	}
 	
@@ -56,5 +81,21 @@ public class PredicateRegistry {
 		if ( !predicateExists( res, jType ) ) 
 			return false;
 		return reqPredicates.get( jType.toString()+";"+res.toString() ).test(player); 
+	}
+	
+	/**this is executed by PMMO logic to determine if the player is permitted to break
+	 * the block according to the object and type contexts.  
+	 * 
+	 * @param player the player performing the action
+	 * @param res res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @return whether the player is permitted to do the action (true if yes)
+	 */
+	public static boolean checkPredicateReq(PlayerEntity player, TileEntity tile, JType jType) 
+	{
+		ResourceLocation res = tile.getBlockState().getBlock().getRegistryName();
+		if ( !predicateExists( res, jType ) ) 
+			return false;
+		return reqBreakPredicates.get( jType.toString()+";"+res.toString() ).test(player, tile); 
 	}
 }

--- a/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
+++ b/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
@@ -14,6 +14,16 @@ public class PredicateRegistry {
 	
 	private static Map<String, Predicate<PlayerEntity>> reqPredicates = new HashMap<>();
 	
+	/** registers a predicate to be used in determining if a given player is permitted
+	 * to perform a particular action.  The ResouceLocation and JType parameters are 
+	 * conditions for when this check should be applied and are used by PMMO to know
+	 * which predicates apply in which contexts.  The predicate itself links to the 
+	 * compat mod's logic which handles the external behavior.
+	 * 
+	 * @param res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param pred what executes to determine if player is permitted to perform the action
+	 */
 	public static void registerPredicate(ResourceLocation res, JType jType, Predicate<PlayerEntity> pred) 
 	{
 		String condition = jType.toString()+";"+res.toString();
@@ -23,11 +33,25 @@ public class PredicateRegistry {
 		XP.LOGGER.info("Predicate Registered: "+condition);
 	}
 	
+	/**this is an internal method to check if a predicate exists for the given conditions
+	 * 
+	 * @param res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @return whether or not a predicate is registered for the parameters
+	 */
 	public static boolean predicateExists(ResourceLocation res, JType jType) 
 	{
 		return reqPredicates.containsKey(jType.toString()+";"+res.toString());
 	}
 	
+	/**this is executed by PMMO logic to determine if the player is permitted to perform
+	 * the action according to the object and type contexts.  
+	 * 
+	 * @param player the player performing the action
+	 * @param res res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @return whether the player is permitted to do the action (true if yes)
+	 */
 	public static boolean checkPredicateReq(PlayerEntity player, ResourceLocation res, JType jType) 
 	{
 		return reqPredicates.get(jType.toString()+";"+res.toString()).test(player); 

--- a/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
+++ b/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import harmonised.pmmo.config.JType;
-import harmonised.pmmo.config.JsonConfig;
 import harmonised.pmmo.util.XP;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ResourceLocation;
@@ -27,9 +26,9 @@ public class PredicateRegistry {
 	public static void registerPredicate(ResourceLocation res, JType jType, Predicate<PlayerEntity> pred) 
 	{
 		String condition = jType.toString()+";"+res.toString();
-		if (pred == null) return;
-		reqPredicates.put(condition, pred);
-		JsonConfig.data.get(jType).remove(res.toString());
+		if ( pred == null ) 
+			return;
+		reqPredicates.put( condition, pred );
 		XP.LOGGER.info("Predicate Registered: "+condition);
 	}
 	
@@ -41,7 +40,7 @@ public class PredicateRegistry {
 	 */
 	public static boolean predicateExists(ResourceLocation res, JType jType) 
 	{
-		return reqPredicates.containsKey(jType.toString()+";"+res.toString());
+		return reqPredicates.containsKey( jType.toString()+";"+res.toString() );
 	}
 	
 	/**this is executed by PMMO logic to determine if the player is permitted to perform
@@ -54,6 +53,8 @@ public class PredicateRegistry {
 	 */
 	public static boolean checkPredicateReq(PlayerEntity player, ResourceLocation res, JType jType) 
 	{
-		return reqPredicates.get(jType.toString()+";"+res.toString()).test(player); 
+		if ( !predicateExists( res, jType ) ) 
+			return false;
+		return reqPredicates.get( jType.toString()+";"+res.toString() ).test(player); 
 	}
 }

--- a/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
+++ b/src/main/java/harmonised/pmmo/api/PredicateRegistry.java
@@ -1,0 +1,35 @@
+package harmonised.pmmo.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import harmonised.pmmo.config.JType;
+import harmonised.pmmo.config.JsonConfig;
+import harmonised.pmmo.util.XP;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.ResourceLocation;
+
+public class PredicateRegistry {
+	
+	private static Map<String, Predicate<PlayerEntity>> reqPredicates = new HashMap<>();
+	
+	public static void registerPredicate(ResourceLocation res, JType jType, Predicate<PlayerEntity> pred) 
+	{
+		String condition = jType.toString()+";"+res.toString();
+		if (pred == null) return;
+		reqPredicates.put(condition, pred);
+		JsonConfig.data.get(jType).remove(res.toString());
+		XP.LOGGER.info("Predicate Registered: "+condition);
+	}
+	
+	public static boolean predicateExists(ResourceLocation res, JType jType) 
+	{
+		return reqPredicates.containsKey(jType.toString()+";"+res.toString());
+	}
+	
+	public static boolean checkPredicateReq(PlayerEntity player, ResourceLocation res, JType jType) 
+	{
+		return reqPredicates.get(jType.toString()+";"+res.toString()).test(player); 
+	}
+}

--- a/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
+++ b/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
@@ -16,6 +16,17 @@ public class TooltipSupplier {
 	public static final Logger LOGGER = LogManager.getLogger();
 	private static Map<JType, Map<ResourceLocation, Function<ItemStack, Map<String, Double>>>> tooltips = new HashMap<>();
 	
+	/**registers a Function to be used in providing the requirements for specific item
+	 * skill requirements. The map consists of skill name and skill value pairs.  
+	 * The ResouceLocation and JType parameters are conditions for when this check
+	 * should be applied and are used by PMMO to know which functions apply in which
+	 * contexts.  The function itself links to the compat mod's logic which handles 
+	 * the external behavior.
+	 *  
+	 * @param res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param func returns a map of skills and required levels
+	 */
 	public static void registerTooltipData(ResourceLocation res, JType jType, Function<ItemStack, Map<String, Double>> func) 
 	{
 		if (func == null) {LOGGER.info("Supplied Function Null"); return;}
@@ -31,6 +42,12 @@ public class TooltipSupplier {
 		tooltips.get(jType).put(res, func);
 	}
 	
+	/**this is an internal method to check if a function exists for the given conditions
+	 * 
+	 * @param res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @return whether or not a function is registered for the parameters
+	 */
 	public static boolean tooltipExists(ResourceLocation res, JType jType)
 	{
 		if (jType == null) return false;
@@ -39,10 +56,20 @@ public class TooltipSupplier {
 		return tooltips.get(jType).containsKey(res);
 	}
 	
+	/**this is executed by PMMO where the requirde map for tooltips is used.  some PMMO
+	 * behavior uses this map before a a requirement check for adding things like dynamic
+	 * values. 
+	 * 
+	 * @param res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param stack the itemstack being evaluated for skill requirements
+	 * @return the skill requirements of the item.
+	 */	
 	public static Map<String, Double> getTooltipData(ResourceLocation res, JType jType, ItemStack stack)
 	{
 		if (tooltipExists(res, jType)) {
-			return tooltips.get(jType).get(res).apply(stack);
+			Map<String, Double> suppliedData = tooltips.get(jType).get(res).apply(stack);
+			return suppliedData == null ? new HashMap<>() : suppliedData;
 		}				
 		return JsonConfig.data.get(jType).get(res.toString());
 	}

--- a/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
+++ b/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
@@ -70,7 +70,7 @@ public class TooltipSupplier {
 		if (tooltipExists(res, jType)) {
 			Map<String, Double> suppliedData = tooltips.get(jType).get(res).apply(stack);
 			return suppliedData == null ? new HashMap<>() : suppliedData;
-		}				
-		return JsonConfig.data.get(jType).get(res.toString());
+		}	
+		return JsonConfig.data.getOrDefault(jType, new HashMap<>()).getOrDefault(res.toString(), new HashMap<>());
 	}
 }

--- a/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
+++ b/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
@@ -1,0 +1,49 @@
+package harmonised.pmmo.api;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import harmonised.pmmo.config.JType;
+import harmonised.pmmo.config.JsonConfig;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public class TooltipSupplier {
+	public static final Logger LOGGER = LogManager.getLogger();
+	private static Map<JType, Map<ResourceLocation, Function<ItemStack, Map<String, Double>>>> tooltips = new HashMap<>();
+	
+	public static void registerTooltipData(ResourceLocation res, JType jType, Function<ItemStack, Map<String, Double>> func) 
+	{
+		if (func == null) {LOGGER.info("Supplied Function Null"); return;}
+		if (jType == null) {LOGGER.info("Supplied JType Null"); return;}
+		if (res == null) {LOGGER.info("Supplied ResourceLocation Null"); return;}
+		
+		if (!tooltips.containsKey(jType)) {
+			LOGGER.info("New tooltip category created for: "+jType.toString()+" "+res.toString());
+			tooltips.put(jType, new HashMap<ResourceLocation, Function<ItemStack, Map<String, Double>>>());
+		}
+		if (tooltipExists(res, jType)) return;
+		//TODO implement existing function checker/logger though might not be needed
+		tooltips.get(jType).put(res, func);
+	}
+	
+	public static boolean tooltipExists(ResourceLocation res, JType jType)
+	{
+		if (jType == null) return false;
+		if (res == null) return false;
+		if (!tooltips.containsKey(jType)) return false;
+		return tooltips.get(jType).containsKey(res);
+	}
+	
+	public static Map<String, Double> getTooltipData(ResourceLocation res, JType jType, ItemStack stack)
+	{
+		if (tooltipExists(res, jType)) {
+			return tooltips.get(jType).get(res).apply(stack);
+		}				
+		return JsonConfig.data.get(jType).get(res.toString());
+	}
+}

--- a/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
+++ b/src/main/java/harmonised/pmmo/api/TooltipSupplier.java
@@ -10,11 +10,13 @@ import org.apache.logging.log4j.Logger;
 import harmonised.pmmo.config.JType;
 import harmonised.pmmo.config.JsonConfig;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 
 public class TooltipSupplier {
 	public static final Logger LOGGER = LogManager.getLogger();
 	private static Map<JType, Map<ResourceLocation, Function<ItemStack, Map<String, Double>>>> tooltips = new HashMap<>();
+	private static Map<JType, Map<ResourceLocation, Function<TileEntity, Map<String, Double>>>> breakTooltips = new HashMap<>();
 	
 	/**registers a Function to be used in providing the requirements for specific item
 	 * skill requirements. The map consists of skill name and skill value pairs.  
@@ -35,11 +37,37 @@ public class TooltipSupplier {
 		
 		if (!tooltips.containsKey(jType)) {
 			LOGGER.info("New tooltip category created for: "+jType.toString()+" "+res.toString());
-			tooltips.put(jType, new HashMap<ResourceLocation, Function<ItemStack, Map<String, Double>>>());
+			tooltips.put(jType, new HashMap<>());
 		}
 		if (tooltipExists(res, jType)) return;
 		//TODO implement existing function checker/logger though might not be needed
 		tooltips.get(jType).put(res, func);
+	}
+	
+	/**registers a Function to be used in providing the requirements for specific item
+	 * skill requirements. The map consists of skill name and skill value pairs.  
+	 * The ResouceLocation and JType parameters are conditions for when this check
+	 * should be applied and are used by PMMO to know which functions apply in which
+	 * contexts.  The function itself links to the compat mod's logic which handles 
+	 * the external behavior.
+	 *  
+	 * @param res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param func returns a map of skills and required levels
+	 */
+	public static void registerBreakTooltipData(ResourceLocation res, JType jType, Function<TileEntity, Map<String, Double>> func) 
+	{
+		if (func == null) {LOGGER.info("Supplied Function Null"); return;}
+		if (jType == null) {LOGGER.info("Supplied JType Null"); return;}
+		if (res == null) {LOGGER.info("Supplied ResourceLocation Null"); return;}
+		
+		if (!breakTooltips.containsKey(jType)) {
+			LOGGER.info("New tooltip category created for: "+jType.toString()+" "+res.toString());
+			breakTooltips.put(jType, new HashMap<>());
+		}
+		if (tooltipExists(res, jType)) return;
+		//TODO implement existing function checker/logger though might not be needed
+		breakTooltips.get(jType).put(res, func);
 	}
 	
 	/**this is an internal method to check if a function exists for the given conditions
@@ -52,11 +80,19 @@ public class TooltipSupplier {
 	{
 		if (jType == null) return false;
 		if (res == null) return false;
-		if (!tooltips.containsKey(jType)) return false;
+		if (!tooltips.containsKey(jType)) 
+			return false;
+		
+		if (jType.equals(JType.REQ_BREAK)) 
+		{
+			if (!breakTooltips.containsKey(jType)) 
+				return false;
+			return breakTooltips.get(jType).containsKey(res);
+		}
 		return tooltips.get(jType).containsKey(res);
 	}
 	
-	/**this is executed by PMMO where the requirde map for tooltips is used.  some PMMO
+	/**this is executed by PMMO where the required map for tooltips is used.  some PMMO
 	 * behavior uses this map before a a requirement check for adding things like dynamic
 	 * values. 
 	 * 
@@ -69,6 +105,24 @@ public class TooltipSupplier {
 	{
 		if (tooltipExists(res, jType)) {
 			Map<String, Double> suppliedData = tooltips.get(jType).get(res).apply(stack);
+			return suppliedData == null ? new HashMap<>() : suppliedData;
+		}	
+		return JsonConfig.data.getOrDefault(jType, new HashMap<>()).getOrDefault(res.toString(), new HashMap<>());
+	}
+	
+	/**this is executed by PMMO where the required map for break tooltips are used.  some PMMO
+	 * behavior uses this map before a a requirement check for adding things like dynamic
+	 * values. 
+	 * 
+	 * @param res res the block, item, or entity registrykey
+	 * @param jType the PMMO behavior type
+	 * @param stack the itemstack being evaluated for skill requirements
+	 * @return the skill requirements of the item.
+	 */	
+	public static Map<String, Double> getTooltipData(ResourceLocation res, JType jType, TileEntity tile)
+	{
+		if (tooltipExists(res, jType)) {
+			Map<String, Double> suppliedData = breakTooltips.get(jType).get(res).apply(tile);
 			return suppliedData == null ? new HashMap<>() : suppliedData;
 		}	
 		return JsonConfig.data.getOrDefault(jType, new HashMap<>()).getOrDefault(res.toString(), new HashMap<>());

--- a/src/main/java/harmonised/pmmo/events/BreakSpeedHandler.java
+++ b/src/main/java/harmonised/pmmo/events/BreakSpeedHandler.java
@@ -83,7 +83,9 @@ public class BreakSpeedHandler
         int toolGap = XP.getSkillReqGap( player, toolReq );
         int enchantGap = XP.getSkillReqGap( player, XP.getEnchantsUseReq( player.getHeldItemMainhand() ) );
         int gap = Math.max( Math.max( toolGap, enchantGap ), tinkersMaterialsReqGap );
-        boolean breakReqMet = XP.checkReq( player, event.getState().getBlock().getRegistryName(), JType.REQ_BREAK );
+        boolean breakReqMet = event.getState().hasTileEntity()
+        		? XP.checkReq( player, event.getEntity().getEntityWorld().getTileEntity(event.getPos()), JType.REQ_BREAK)
+        		: XP.checkReq( player, event.getState().getBlock().getRegistryName(), JType.REQ_BREAK );
 
         if( !breakReqMet )
         {

--- a/src/main/java/harmonised/pmmo/events/BreakSpeedHandler.java
+++ b/src/main/java/harmonised/pmmo/events/BreakSpeedHandler.java
@@ -1,6 +1,7 @@
 package harmonised.pmmo.events;
 
 import harmonised.pmmo.ProjectMMOMod;
+import harmonised.pmmo.api.TooltipSupplier;
 import harmonised.pmmo.config.AutoValues;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.JType;
@@ -35,7 +36,7 @@ public class BreakSpeedHandler
         ResourceLocation resLoc = itemStack.getItem().getRegistryName();
         if( resLoc == null )
             return;
-        Map<String, Double> toolReq = XP.getJsonMap( resLoc, JType.REQ_TOOL );
+        Map<String, Double> toolReq = TooltipSupplier.getTooltipData(resLoc, JType.REQ_TOOL, itemStack);
         if( Config.getConfig( "toolReqEnabled" ) != 0 && Config.getConfig( "autoGenerateValuesEnabled" ) != 0 && Config.getConfig( "autoGenerateToolReqDynamicallyEnabled" ) != 0 )
         {
             Map<String, Double> dynToolReq = AutoValues.getToolReqFromStack( itemStack );

--- a/src/main/java/harmonised/pmmo/events/TooltipHandler.java
+++ b/src/main/java/harmonised/pmmo/events/TooltipHandler.java
@@ -1,5 +1,6 @@
 package harmonised.pmmo.events;
 
+import harmonised.pmmo.api.TooltipSupplier;
 import harmonised.pmmo.config.AutoValues;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.JType;
@@ -11,7 +12,6 @@ import harmonised.pmmo.util.Util;
 import harmonised.pmmo.util.XP;
 import harmonised.pmmo.util.DP;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.material.Material;
 import net.minecraft.client.Minecraft;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.BlockItem;
@@ -74,14 +74,14 @@ public class TooltipHandler
                     return;
                 }
 
-                Map<String, Double> craftReq = JsonConfig.data.get( JType.REQ_CRAFT ).get( regKey );
-                Map<String, Double> wearReq = JsonConfig.data.get( JType.REQ_WEAR ).get( regKey );
-                Map<String, Double> toolReq = JsonConfig.data.get( JType.REQ_TOOL ).get( regKey );
-                Map<String, Double> weaponReq = JsonConfig.data.get( JType.REQ_WEAPON ).get( regKey );
-                Map<String, Double> useReq = JsonConfig.data.get( JType.REQ_USE ).get( regKey );
+                Map<String, Double> craftReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_CRAFT, itemStack);
+                Map<String, Double> wearReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_WEAR, itemStack);
+                Map<String, Double> toolReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_TOOL, itemStack);
+                Map<String, Double> weaponReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_WEAPON, itemStack);
+                Map<String, Double> useReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_USE, itemStack);
                 Map<String, Double> useEnchantmentReq = XP.getEnchantsUseReq( itemStack );
-                Map<String, Double> placeReq = JsonConfig.data.get( JType.REQ_PLACE ).get( regKey );
-                Map<String, Double> breakReq = JsonConfig.data.get( JType.REQ_BREAK ).get( regKey );
+                Map<String, Double> placeReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_PLACE, itemStack);
+                Map<String, Double> breakReq = TooltipSupplier.getTooltipData(new ResourceLocation(regKey), JType.REQ_BREAK, itemStack);
                 Map<String, Double> xpValueGeneral = JsonConfig.data.get( JType.XP_VALUE_GENERAL ).get( regKey );
                 Map<String, Double> xpValueBreaking = JsonConfig.data.get( JType.XP_VALUE_BREAK ).get( regKey );
                 Map<String, Double> xpValueCrafting = JsonConfig.data.get( JType.XP_VALUE_CRAFT ).get( regKey );

--- a/src/main/java/harmonised/pmmo/util/XP.java
+++ b/src/main/java/harmonised/pmmo/util/XP.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import harmonised.pmmo.api.PredicateRegistry;
-import harmonised.pmmo.api.TooltipSupplier;
 import harmonised.pmmo.config.AutoValues;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.JType;
@@ -25,7 +24,6 @@ import harmonised.pmmo.skills.PMMOFireworkEntity;
 import harmonised.pmmo.skills.Skill;
 import net.minecraft.block.*;
 import net.minecraft.block.material.Material;
-import net.minecraft.client.Minecraft;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.*;
@@ -44,6 +42,7 @@ import net.minecraft.potion.EffectInstance;
 import net.minecraft.potion.Effects;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.tags.*;
+import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.*;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.vector.Vector3d;
@@ -51,7 +50,6 @@ import net.minecraft.util.registry.Registry;
 import net.minecraft.util.text.*;
 import net.minecraft.world.World;
 import net.minecraft.world.biome.Biome;
-
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.ForgeRegistries;
@@ -732,6 +730,21 @@ public class XP
 	public static boolean checkReq( PlayerEntity player, String res, JType jType )
 	{
 		return checkReq( player, XP.getResLoc( res ), jType );
+	}
+	
+	@SuppressWarnings("deprecation")
+	public static boolean checkReq( PlayerEntity player, TileEntity tile, JType jType )
+	{
+		if( tile == null )
+			return true;
+		
+		if( tile.getBlockState().isAir() )
+			return true;
+		
+		if( PredicateRegistry.predicateExists(tile.getBlockState().getBlock().getRegistryName(), jType))
+			return PredicateRegistry.checkPredicateReq(player, tile, jType);
+		
+		return checkReq( player, getJsonMap( tile.getBlockState().getBlock().getRegistryName().toString(), jType ) );
 	}
 
 	public static boolean checkReq( PlayerEntity player, ResourceLocation res, JType jType )

--- a/src/main/java/harmonised/pmmo/util/XP.java
+++ b/src/main/java/harmonised/pmmo/util/XP.java
@@ -6,6 +6,7 @@ import java.util.stream.Collectors;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import harmonised.pmmo.api.PredicateRegistry;
+import harmonised.pmmo.api.TooltipSupplier;
 import harmonised.pmmo.config.AutoValues;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.JType;

--- a/src/main/java/harmonised/pmmo/util/XP.java
+++ b/src/main/java/harmonised/pmmo/util/XP.java
@@ -4,6 +4,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import harmonised.pmmo.api.PredicateRegistry;
 import harmonised.pmmo.config.AutoValues;
 import harmonised.pmmo.config.Config;
 import harmonised.pmmo.config.JType;
@@ -738,7 +740,10 @@ public class XP
 
 		if( res.equals( Items.AIR.getRegistryName() ) || player.isCreative() )
 			return true;
-
+		
+		if( PredicateRegistry.predicateExists(res, jType)) 
+			return PredicateRegistry.checkPredicateReq(player, res, jType);
+		
 		return checkReq( player, getJsonMap( res.toString(), jType ) );
 	}
 
@@ -910,67 +915,67 @@ public class XP
 		return matched;
 	}
 
-//	public static CompoundNBT getPmmoTag( PlayerEntity player )
-//	{
-//		if( player != null )
-//		{
-//			CompoundNBT persistTag = player.getPersistentData();
-//			CompoundNBT pmmoTag = null;
-//
-//			if( !persistTag.contains( Reference.MOD_ID ) )			//if Player doesn't have pmmo tag, make it
-//			{
-//				pmmoTag = new CompoundNBT();
-//				persistTag.put( Reference.MOD_ID, pmmoTag );
-//			}
-//			else
-//			{
-//				pmmoTag = persistTag.getCompound( Reference.MOD_ID );	//if Player has pmmo tag, use it
-//			}
-//
-//			return pmmoTag;
-//		}
-//		else
-//			return new CompoundNBT();
-//	}
-//
-//	public static CompoundNBT getPmmoTagElement( PlayerEntity player, String element )
-//	{
-//		if( player != null )
-//		{
-//			CompoundNBT pmmoTag = getPmmoTag( player );
-//			CompoundNBT elementTag = null;
-//
-//			if( !pmmoTag.contains( element ) )					//if Player doesn't have element tag, make it
-//			{
-//				elementTag = new CompoundNBT();
-//				pmmoTag.put( element, elementTag );
-//			}
-//			else
-//			{
-//				elementTag = pmmoTag.getCompound( element );	//if Player has element tag, use it
-//			}
-//
-//			return elementTag;
-//		}
-//		else
-//			return new CompoundNBT();
-//	}
-//
-//	public static CompoundNBT getxpMap( PlayerEntity player )
-//	{
-//		return getPmmoTagElement( player, "skills" );
-//	}
-//
-//	public static CompoundNBT getPreferencesTag( PlayerEntity player )
-//	{
-//		return getPmmoTagElement( player, "preferences" );
-//	}
-//
-//	public static CompoundNBT getabilitiesMap( PlayerEntity player )
-//	{
-//		return getPmmoTagElement( player, "abilities" );
-//	}
+/*	public static CompoundNBT getPmmoTag( PlayerEntity player )
+	{
+		if( player != null )
+		{
+			CompoundNBT persistTag = player.getPersistentData();
+			CompoundNBT pmmoTag = null;
 
+			if( !persistTag.contains( Reference.MOD_ID ) )			//if Player doesn't have pmmo tag, make it
+			{
+				pmmoTag = new CompoundNBT();
+				persistTag.put( Reference.MOD_ID, pmmoTag );
+			}
+			else
+			{
+				pmmoTag = persistTag.getCompound( Reference.MOD_ID );	//if Player has pmmo tag, use it
+			}
+
+			return pmmoTag;
+		}
+		else
+			return new CompoundNBT();
+	}
+*/
+/*	public static CompoundNBT getPmmoTagElement( PlayerEntity player, String element )
+	{
+		if( player != null )
+		{
+			CompoundNBT pmmoTag = getPmmoTag( player );
+			CompoundNBT elementTag = null;
+
+			if( !pmmoTag.contains( element ) )					//if Player doesn't have element tag, make it
+			{
+				elementTag = new CompoundNBT();
+				pmmoTag.put( element, elementTag );
+			}
+			else
+			{
+				elementTag = pmmoTag.getCompound( element );	//if Player has element tag, use it
+			}
+
+			return elementTag;
+		}
+		else
+			return new CompoundNBT();
+	}
+*/
+/*	public static CompoundNBT getxpMap( PlayerEntity player )
+	{
+		return getPmmoTagElement( player, "skills" );
+	}
+*/
+/*	public static CompoundNBT getPreferencesTag( PlayerEntity player )
+	{
+		return getPmmoTagElement( player, "preferences" );
+	}
+*/
+/*	public static CompoundNBT getabilitiesMap( PlayerEntity player )
+	{
+		return getPmmoTagElement( player, "abilities" );
+	}
+*/
 	public static double getMaxLevel()
 	{
 		double serverMaxLevel = Config.getConfig( "maxLevel" );


### PR DESCRIPTION
This is an initial implementation of a PMMO API framework.  This initial implementation is primary to expose features of PMMO for the use in my NBT compat mod.

This PR includes a new package `api` that contains two new classes as API hooks.  `PredicateRegistry` is where mods can register their pass/fail logic in the form of a `java.util.function.Predicate`.  an example implementation would be: 
`
Predicate<PlayerEntity> pred = player -> (playerCanDoAction(player, resourceLocation, jType));
PredicateRegistry.registerPredicate(resourceLocation, jType, pred);
`

`TooltipSupplier` is where mods will register what should appear on the tooltip.  It is important to note that the `Map<String, Double>` result of `getToolTipData` is used by `BreakSpeedHandler` to get the requirements.  Since the nature of NBT means ItemStacks can be dynamic, mapping them is not practical and needs to be referenced in place of `JsonConfig.data`  An example implementation would be:
`
Function<ItemStack, Map<String, Double>> func = stack -> (getRequirementsMap(jType, stack));
TooltipSupplier.registerTooltipData(resourceLocation, jType, func);
`

*I also changed some commenting in `XP.java` to make those commented blocks foldable*