### PR TITLE
Event Tweak 

### DIFF
--- a/src/main/java/harmonised/pmmo/api/perks/PerkRegistry.java
+++ b/src/main/java/harmonised/pmmo/api/perks/PerkRegistry.java
@@ -3,6 +3,7 @@ package harmonised.pmmo.api.perks;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.lang3.function.TriFunction;
 import com.google.common.base.Preconditions;
@@ -92,10 +93,15 @@ public class PerkRegistry {
 		}
 	}
 	
-	private static CompoundTag mergeTags(CompoundTag tag1, CompoundTag tag2) {
+	public static CompoundTag mergeTags(CompoundTag tag1, CompoundTag tag2) {
 		CompoundTag output = new CompoundTag();
-		for (String key : tag1.getAllKeys()) {
-			if (tag2.contains(key)) {
+		Set<String> allKeys = tag1.getAllKeys();
+		for (String key : tag2.getAllKeys()) {
+			if (!allKeys.contains(key))
+				allKeys.add(key);
+		}
+		for (String key : allKeys) {
+			if (tag1.contains(key) && tag2.contains(key)) {
 				if (tag1.get(key) instanceof NumericTag) {
 					if (tag1.get(key) instanceof DoubleTag)
 						output.putDouble(key, tag1.getDouble(key) + tag2.getDouble(key));
@@ -113,6 +119,10 @@ public class PerkRegistry {
 				else
 					output.put(key, tag1.get(key));
 			}
+			else if (tag1.contains(key) && !tag2.contains(key))
+				output.put(key, tag1.get(key));
+			else if (!tag1.contains(key) && tag2.contains(key))
+				output.put(key, tag2.get(key));				
 		}
 		return output;
 	}

--- a/src/main/java/harmonised/pmmo/events/EventHandler.java
+++ b/src/main/java/harmonised/pmmo/events/EventHandler.java
@@ -28,12 +28,14 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void blockBroken(BreakEvent event)
 	{
+		if (event.isCanceled()) return;
 		BlockBrokenHandler.handleBroken(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void blockPlaced(BlockEvent.EntityMultiPlaceEvent event)
 	{
+		if (event.isCanceled()) return;
 		if(event.getEntity() != null && BlockPlacedHandler.handlePlaced(event.getEntity(), event.getPlacedBlock(), (Level) event.getWorld(), event.getPos()))
 			event.setCanceled(true);
 	}
@@ -41,6 +43,7 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void blockPlaced(BlockEvent.EntityPlaceEvent event)
 	{
+		if (event.isCanceled()) return;
 		if(event.getEntity() != null && BlockPlacedHandler.handlePlaced(event.getEntity(), event.getPlacedBlock(), (Level) event.getWorld(), event.getPos()))
 			event.setCanceled(true);
 	}
@@ -48,12 +51,14 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void livingHurt(LivingHurtEvent event)
 	{
+		if (event.isCanceled()) return;
 		DamageHandler.handleDamage(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void livingDeath(LivingDeathEvent event)
 	{
+		if (event.isCanceled()) return;
 		DeathHandler.handleDeath(event);
 	}
 
@@ -66,18 +71,21 @@ public class EventHandler
 	@SubscribeEvent
 	public static void playerRespawn(PlayerEvent.PlayerRespawnEvent event)
 	{
+		if (event.isCanceled()) return;
 		PlayerRespawnHandler.handlePlayerRespawn(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void livingJump(LivingJumpEvent event)
 	{
+		if (event.isCanceled()) return;
 		JumpHandler.handleJump(event);
 	}
 
 	@SubscribeEvent
 	public static void PlayerLogin(PlayerEvent.PlayerLoggedInEvent event)
 	{
+		if (event.isCanceled()) return;
 		PlayerConnectedHandler.handlePlayerConnected(event);
 	}
 
@@ -96,12 +104,14 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void onAnvilRepair(AnvilRepairEvent event)
 	{
+		if (event.isCanceled()) return;
 		AnvilRepairHandler.handleAnvilRepair(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void onItemFished(ItemFishedEvent event)
 	{
+		if (event.isCanceled()) return;
 		FishedHandler.handleFished(event);
 	}
 
@@ -109,36 +119,42 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void itemCrafted(PlayerEvent.ItemCraftedEvent event)
 	{
+		if (event.isCanceled()) return;
 		CraftedHandler.handleCrafted(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void breakSpeed(PlayerEvent.BreakSpeed event)
 	{
+		if (event.isCanceled()) return;
 		BreakSpeedHandler.handleBreakSpeed(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void playerInteract(PlayerInteractEvent event)
 	{
+		if (event.isCanceled()) return;
 		PlayerInteractionHandler.handlePlayerInteract(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void livingSpawn(LivingSpawnEvent.SpecialSpawn event)
 	{
+		if (event.isCanceled()) return;
 		SpawnHandler.handleSpawn(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void babySpawn(BabyEntitySpawnEvent event)
 	{
+		if (event.isCanceled()) return;
 		BreedHandler.handleBreedEvent(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void animalTaming(AnimalTameEvent event)
 	{
+		if (event.isCanceled()) return;
 		TameHandler.handleAnimalTaming(event);
 	}
 
@@ -184,6 +200,7 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void pistonPush(PistonEvent event)
 	{
+		if (event.isCanceled()) return;
 		PistonEventHandler.handlePistonPush(event);
 	}
 
@@ -196,18 +213,21 @@ public class EventHandler
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void saplingGrow(SaplingGrowTreeEvent event)
 	{
+		if (event.isCanceled()) return;
 		GrowHandler.handleSaplingGrow(event);
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void cropGrow(BlockEvent.CropGrowEvent.Post event)
 	{
+		if (event.isCanceled()) return;
 		GrowHandler.handleCropGrow(event);
 	}
 
 	@SubscribeEvent
 	public static void travelDimension(EntityTravelToDimensionEvent event)
 	{
+		if (event.isCanceled()) return;
 		if(event.getEntity() instanceof ServerPlayer)
 		{
 			ServerPlayer player = (ServerPlayer) event.getEntity();

--- a/src/main/resources/assets/pmmo/util/perks.json
+++ b/src/main/resources/assets/pmmo/util/perks.json
@@ -16,21 +16,21 @@
 	"JUMPING": { 
 		"agility": [ 
 			{"perk":"pmmo:jump_boost",
-			 "per_level": 0.005
+			 "per_level": 0.0005
 			}
 		]
 	},
 	"SPRINT_JUMP": { 
 		"agility": [ 
 			{"perk":"pmmo:jump_boost",
-			 "per_level": 0.01
+			 "per_level": 0.001
 			}
 		]
 	},
 	"CROUCH_JUMP": { 
 		"agility": [ 
 			{"perk":"pmmo:jump_boost",
-			 "per_level": 0.015
+			 "per_level": 0.0015
 			}
 		]
 	},


### PR DESCRIPTION
This updates the Event calls to first check for cancellation before executing.  This resolves an issue presented where another mod cancelled an event but PMMO still proceeded to break the block and vein mine.  

*There is also some value changes to `perks.json` to reduce early game jump boost.*