### PR TITLE
Update dependency for Dynamic Trees 1.16 to Beta30

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -151,8 +151,8 @@ dependencies
             runtimeOnly fg.deobf("curse.maven:cgm:3224957")
             runtimeOnly fg.deobf("curse.maven:obfuscate:3336021")
 
-            compileOnly fg.deobf("curse.maven:dynamictrees:3304858")
-            runtimeOnly fg.deobf("curse.maven:dynamictrees:3304858")
+            compileOnly fg.deobf("curse.maven:dynamictrees:3611214")
+            runtimeOnly fg.deobf("curse.maven:dynamictrees:3611214")
 
 
 //            compileOnly fg.deobf("curse.maven:engineers-decor:3253781")

--- a/src/main/java/harmonised/pmmo/util/DrawUtil.java
+++ b/src/main/java/harmonised/pmmo/util/DrawUtil.java
@@ -1,7 +1,6 @@
 package harmonised.pmmo.util;
 
 import com.google.common.collect.Lists;
-import javafx.util.Pair;
 import net.minecraft.block.BlockState;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;


### PR DESCRIPTION
Update Gradle build file Dynamic Trees dependency to the Beta30 version. Testing in a Single Player world indicates this has fixed the tree chopping crash which appeared to be as a result of DT changing INodeInspector to NodeInspector.

Also removed an unneeded import of javafx. Please can you build and update the CurseForge version.