### PR TITLE
strictReqWeapon fix

### DIFF
--- a/src/main/java/harmonised/pmmo/events/EventHandler.java
+++ b/src/main/java/harmonised/pmmo/events/EventHandler.java
@@ -45,6 +45,12 @@ public class EventHandler
 	}
 
 	@SubscribeEvent(priority = EventPriority.LOWEST)
+	public static void livingAttack(LivingAttackEvent event)
+	{
+		DamageHandler.handleAttack(event);
+	}
+
+	@SubscribeEvent(priority = EventPriority.LOWEST)
 	public static void livingHurt(LivingHurtEvent event)
 	{
 		DamageHandler.handleDamage(event);


### PR DESCRIPTION
Moved **strictReqWeapon** check to **LivingAttackEvent**
This is so it properly cancels the attack, preventing any on-hit effects (like Flame, Fire Aspect, and some effects from other mods)