### PR TITLE
40.0.18+ port 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ mixin
 }
 apply plugin: 'maven-publish'
 
-version = '1.18.2-3.69.8'
+version = '1.18.2-3.69.9'
 group = 'harmonised.pmmo'
 archivesBaseName = 'Project_MMO'
 

--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ repositories
 
 dependencies
         {
-            minecraft 'net.minecraftforge:forge:1.18.1-39.0.55'
+            minecraft 'net.minecraftforge:forge:1.18.2-40.0.36'
             annotationProcessor "org.spongepowered:mixin:0.8.5:processor"
 
 //            compileOnly fg.deobf("mezz.jei:jei-1.17.1-8.0.0.16:api")
@@ -129,16 +129,16 @@ dependencies
 
 //            runtimeOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.2:7.0.0.27")
 //            compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-1.16.2:7.0.0.27")
-            compileOnly fg.deobf("curse.maven:ftb-quests-forge:3596442")
-//            runtimeOnly fg.deobf("curse.maven:ftb-quests-forge:3596442")
-            compileOnly fg.deobf("curse.maven:ftb-library-forge:3598890")
-//            runtimeOnly fg.deobf("curse.maven:ftb-library-forge:3598890")
-            compileOnly fg.deobf("curse.maven:item-filters-forge:3596362")
-//            runtimeOnly fg.deobf("curse.maven:item-filters-forge:3596362")
-            compileOnly fg.deobf("curse.maven:ftb-teams-forge:3596307")
-//            runtimeOnly fg.deobf("curse.maven:ftb-teams-forge:3596307")
-            compileOnly fg.deobf("curse.maven:architectury-forge:3587338")
-//            runtimeOnly fg.deobf("curse.maven:architectury-forge:3587338")
+            compileOnly fg.deobf("curse.maven:ftbquests-289412:3725771")
+		    //runtimeOnly fg.deobf("curse.maven:ftbquests-289412:3725771")
+		    compileOnly fg.deobf("curse.maven:ftbguilibrary-404465:3725485")
+		    //runtimeOnly fg.deobf("curse.maven:ftbguilibrary-404465:3725485")
+		    compileOnly fg.deobf("curse.maven:itemfilters-309674:3725923")
+		    //runtimeOnly fg.deobf("curse.maven:itemfilters-309674:3725923")
+		    compileOnly fg.deobf("curse.maven:ftbteams-forge-404468:3725501")
+		    //runtimeOnly fg.deobf("curse.maven:ftbteams-forge-404468:3725501")
+		    compileOnly fg.deobf("curse.maven:architecturyforge-419699:3728618")
+		    //runtimeOnly fg.deobf("curse.maven:architecturyforge-419699:3728618")
 
 //            runtimeOnly fg.deobf("curse.maven:cgm:3224957")
 //            runtimeOnly fg.deobf("curse.maven:obfuscate-289380:3458195")

--- a/src/main/java/harmonised/pmmo/commands/CheckBiomeCommand.java
+++ b/src/main/java/harmonised/pmmo/commands/CheckBiomeCommand.java
@@ -21,7 +21,7 @@ public class CheckBiomeCommand
     public static int execute(CommandContext<CommandSourceStack> context) throws CommandRuntimeException
     {
         Player sender = (Player) context.getSource().getEntity();
-        Biome biome = sender.level.getBiomeManager().m_47881_(new BlockPos(sender.position()));
+        Biome biome = sender.level.getBiome(new BlockPos(sender.position())).value();
         ResourceLocation biomeResLoc = XP.getBiomeResLoc(sender.level, biome);
         String biomeKey = biomeResLoc.toString();
         String transKey = Util.makeDescriptionId("biome", biomeResLoc);

--- a/src/main/java/harmonised/pmmo/config/AutoValues.java
+++ b/src/main/java/harmonised/pmmo/config/AutoValues.java
@@ -3,6 +3,7 @@ package harmonised.pmmo.config;
 import com.google.common.collect.Multimap;
 import harmonised.pmmo.pmmo_saved_data.PmmoSavedData;
 import harmonised.pmmo.skills.Skill;
+import harmonised.pmmo.util.Reference;
 import harmonised.pmmo.util.XP;
 import net.minecraft.world.entity.ai.attributes.Attribute;
 import net.minecraft.world.entity.ai.attributes.AttributeModifier;
@@ -17,10 +18,14 @@ import net.minecraft.world.item.crafting.Ingredient;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.StringTag;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
 import net.minecraftforge.registries.ForgeRegistries;
+import net.minecraftforge.registries.tags.IReverseTag;
+
 import org.apache.logging.log4j.*;
 
 import java.util.*;
+import java.util.stream.Stream;
 
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
@@ -383,20 +388,20 @@ public class AutoValues
                         JType jType = JType.NONE;
                         Map<String, Double> infoMap = new HashMap<>();
                         double chance = 0;
-                        Set<ResourceLocation> tags = block.getTags();
+                        List<TagKey<Block>> tags = ForgeRegistries.BLOCKS.tags().getReverseTag(block).map(IReverseTag::getTagKeys).orElseGet(Stream::of).toList();
 
                         //Ore/Log/Plant Extra Chance
-                        if(block instanceof OreBlock || tags.contains(new ResourceLocation("forge:ores")))
+                        if(block instanceof OreBlock || tags.contains(Reference.FORGE_ORES))
                         {
                             jType = JType.INFO_ORE;
                             chance = Config.forgeConfig.defaultExtraChanceOre.get();
                         }
-                        else if(block instanceof CropBlock || tags.contains(new ResourceLocation("minecraft:crops")))
+                        else if(block instanceof CropBlock || tags.contains(Reference.FORGE_CROPS))
                         {
                             jType = JType.INFO_PLANT;
                             chance = Config.forgeConfig.defaultExtraChancePlant.get();
                         }
-                        else if(tags.contains(new ResourceLocation("minecraft:logs")))
+                        else if(tags.contains(Reference.FORGE_LOGS))
                         {
                             jType = JType.INFO_LOG;
                             chance = Config.forgeConfig.defaultExtraChanceLog.get();

--- a/src/main/java/harmonised/pmmo/events/PlayerTickHandler.java
+++ b/src/main/java/harmonised/pmmo/events/PlayerTickHandler.java
@@ -237,7 +237,7 @@ public class PlayerTickHandler
                     }
                 }
 
-                if(player.isInWater() && (waterAbove || waterBelow || player.m_19941_(FluidTags.WATER)))
+                if(player.isInWater() && (waterAbove || waterBelow || player.isEyeInFluid(FluidTags.WATER)))
                 {
                     if(!player.isSprinting())
                     {

--- a/src/main/java/harmonised/pmmo/events/PlayerTickHandler.java
+++ b/src/main/java/harmonised/pmmo/events/PlayerTickHandler.java
@@ -55,7 +55,7 @@ public class PlayerTickHandler
             	PerkRegistry.executePerk(PerkTrigger.SPRINTING, player);
             else 
             	PerkRegistry.terminatePerk(PerkTrigger.SPRINTING, player);
-            if(player.isSwimming()) 
+            if(player.isUnderWater()) 
             	PerkRegistry.executePerk(PerkTrigger.SUBMERGED, player);
             else 
             	PerkRegistry.terminatePerk(PerkTrigger.SUBMERGED, player);
@@ -116,7 +116,7 @@ public class PlayerTickHandler
 
             double veinGap      = ((System.nanoTime() - lastVeinAward.get     (uuid)) / 1000000000D);
             double cheeseGap    = ((System.nanoTime() - lastCheeseUpdate.get  (uuid)) / 1000000000D);
-            double hpRegenGap   = ((System.nanoTime() - hpRegen.get           (uuid)) / 1000000000D);
+            //double hpRegenGap   = ((System.nanoTime() - hpRegen.get           (uuid)) / 1000000000D);
             double syncGap      = ((System.nanoTime() - sync.get              (uuid)) / 1000000000D);
 
             if(veinGap > 0.25)

--- a/src/main/java/harmonised/pmmo/events/TooltipHandler.java
+++ b/src/main/java/harmonised/pmmo/events/TooltipHandler.java
@@ -522,10 +522,13 @@ public class TooltipHandler
                 //ADVANCED TOOLTIP
                 if(event.getFlags().isAdvanced())
                 {
-                    for(ResourceLocation tagKey : item.getTags())
+                	//Commented out because MC does this automatically with F3+H
+                	//This should also reduce the complaints about tooltip length
+                	//in this version
+                    /*for(ResourceLocation tagKey : item.getTags())
                     {
                         tooltip.add(new TextComponent("#" + tagKey.toString()).setStyle(XP.getColorStyle(0x666666)));
-                    }
+                    }*/
 
                     if(state != null)
                     {

--- a/src/main/java/harmonised/pmmo/perks/EffectPerks.java
+++ b/src/main/java/harmonised/pmmo/perks/EffectPerks.java
@@ -20,20 +20,23 @@ public class EffectPerks {
 
 	public static TriFunction<ServerPlayer, CompoundTag, Integer, CompoundTag> NIGHT_VISION = (player, nbt, level) -> {
 		int min = nbt.contains(MIN_LEVEL) ? nbt.getInt(MIN_LEVEL) : 50;
-		int duration = nbt.contains(DURATION) ? nbt.getInt(DURATION) : 30000;
+		int duration = nbt.contains(DURATION) ? nbt.getInt(DURATION) : 100;
 		if (level < min) return EMPTY;
-		player.addEffect(new MobEffectInstance(MobEffects.NIGHT_VISION, duration));
+		if (!player.hasEffect(MobEffects.NIGHT_VISION) || player.getEffect(MobEffects.NIGHT_VISION).getDuration() <= 80) {
+			player.addEffect(new MobEffectInstance(MobEffects.NIGHT_VISION, duration, 0, true, false, false));
+		}
 		return EMPTY;
 	};
 	
-	public static TriFunction<ServerPlayer, CompoundTag, Integer, CompoundTag> NIGHT_VISION_TERM = (player, nbt, level) -> {
+	//TODO remove entirely.  Implementation of Night Vision Perk has been reworked.
+	/*public static TriFunction<ServerPlayer, CompoundTag, Integer, CompoundTag> NIGHT_VISION_TERM = (player, nbt, level) -> {
 		MobEffectInstance effect = player.getEffect(MobEffects.NIGHT_VISION);
 		if (effect == null) return EMPTY;
 		if (effect.getDuration() > 480) {
 			player.removeEffect(MobEffects.NIGHT_VISION);
 		}
 		return EMPTY;
-	};
+	};*/
 	
 	public static TriFunction<ServerPlayer, CompoundTag, Integer, CompoundTag> REGEN = (player, nbt, level) -> {
 		long cooldown = nbt.contains(COOLDOWN) ? nbt.getLong(COOLDOWN) : 300l;

--- a/src/main/java/harmonised/pmmo/perks/PerkRegistration.java
+++ b/src/main/java/harmonised/pmmo/perks/PerkRegistration.java
@@ -20,7 +20,7 @@ public class PerkRegistration {
 		PerkRegistry.registerPerk(rl("fall_save"), EventPerks.FALL_SAVE, NONE);
 		PerkRegistry.registerPerk(rl("damage_boost"), EventPerks.DAMAGE_BOOST, NONE);
 		//Effect Perks
-		PerkRegistry.registerPerk(rl("night_vision"), EffectPerks.NIGHT_VISION, EffectPerks.NIGHT_VISION_TERM);
+		PerkRegistry.registerPerk(rl("night_vision"), EffectPerks.NIGHT_VISION, NONE);
 		PerkRegistry.registerPerk(rl("regen"), EffectPerks.REGEN, NONE);
 	}
 	

--- a/src/main/java/harmonised/pmmo/skills/AttributeHandler.java
+++ b/src/main/java/harmonised/pmmo/skills/AttributeHandler.java
@@ -93,7 +93,7 @@ public class AttributeHandler
 
 	private static double getBiomeMobMultiplier(Mob mob, String type)
 	{
-		Biome biome = mob.level.getBiomeManager().m_47881_(new BlockPos(mob.position()));
+		Biome biome = mob.level.getBiome(new BlockPos(mob.position())).value();
 		ResourceLocation biomeResLoc = biome.getRegistryName();
 		double multiplier = 1;
 

--- a/src/main/java/harmonised/pmmo/util/Reference.java
+++ b/src/main/java/harmonised/pmmo/util/Reference.java
@@ -1,9 +1,19 @@
 package harmonised.pmmo.util;
 
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.block.Block;
+import net.minecraftforge.registries.ForgeRegistries;
+
 public class Reference 
 {
 	public static final String MOD_ID = "pmmo";
 	public static final String NAME = "Project MMO";
 	public static final String ACCEPTED_VERSIONS = "[1.16.5]";
 	public static final String MC_VERSION = "1.16";
+	
+	public static final TagKey<Block> FORGE_ORES = TagKey.create(ForgeRegistries.BLOCKS.getRegistryKey(), new ResourceLocation("forge:ores"));
+	public static final TagKey<Block> FORGE_LOGS = TagKey.create(ForgeRegistries.BLOCKS.getRegistryKey(), new ResourceLocation("forge:logs"));
+	public static final TagKey<Block> FORGE_PLANTS = TagKey.create(ForgeRegistries.BLOCKS.getRegistryKey(), new ResourceLocation("forge:plants"));
+	public static final TagKey<Block> FORGE_CROPS = TagKey.create(ForgeRegistries.BLOCKS.getRegistryKey(), new ResourceLocation("forge:crops"));
 }

--- a/src/main/java/harmonised/pmmo/util/XP.java
+++ b/src/main/java/harmonised/pmmo/util/XP.java
@@ -146,11 +146,11 @@ public class XP
 
 	public static String getSkill(Block block)
 	{
-		if(block.getTags().contains(getResLoc( "forge:ores")))
+		if(ForgeRegistries.BLOCKS.tags().getTag(Reference.FORGE_ORES).contains(block))
 			return Skill.MINING.toString();
-		else if(block.getTags().contains(getResLoc("forge:logs")))
+		else if(ForgeRegistries.BLOCKS.tags().getTag(Reference.FORGE_LOGS).contains(block))
 			return Skill.WOODCUTTING.toString();
-		else if(block.getTags().contains(getResLoc("forge:plants")))
+		else if(ForgeRegistries.BLOCKS.tags().getTag(Reference.FORGE_PLANTS).contains(block))
 			return Skill.FARMING.toString();
 		else
 			return Skill.INVALID_SKILL.toString();
@@ -250,7 +250,7 @@ public class XP
 
 	public static ResourceLocation getBiomeResLoc(Level world, BlockPos pos)
 	{
-		return world.getBiomeManager().m_47881_(pos).getRegistryName();
+		return world.getBiome(pos).value().getRegistryName();
 	}
 
 	public static ResourceLocation getDimResLoc(Level world)
@@ -853,62 +853,43 @@ public class XP
 
 	public static Set<String> getElementsFromTag(String tag)
 	{
+		ResourceLocation keyRL = new ResourceLocation(tag);
+		TagKey<Item> itemKey = TagKey.create(ForgeRegistries.ITEMS.getRegistryKey(), keyRL);
+		TagKey<Block> blockKey = TagKey.create(ForgeRegistries.BLOCKS.getRegistryKey(), keyRL);
+		TagKey<Fluid> fluidKey = TagKey.create(ForgeRegistries.FLUIDS.getRegistryKey(), keyRL);
+		TagKey<EntityType<?>> entityKey = TagKey.create(ForgeRegistries.ENTITIES.getRegistryKey(), keyRL);
 		Set<String> results = new HashSet<>();
 
-		for(Map.Entry<ResourceLocation, Tag<Item>> namedTag : ItemTags.m_13193_().m_5643_().entrySet())
+		for(Item element : ForgeRegistries.ITEMS.tags().getTag(itemKey).stream().toList())
 		{
-			if(namedTag.getKey().toString().startsWith(tag))
+			try
 			{
-				for(Item element : namedTag.getValue().getValues())
-				{
-					try
-					{
-						results.add(element.getRegistryName().toString());
-					} catch(Exception e){ /* Failed, don't care */ };
-				}
-			}
+				results.add(element.getRegistryName().toString());
+			} catch(Exception e){ /* Failed, don't care */ };
 		}
 
-		for(Map.Entry<ResourceLocation, Tag<Block>> namedTag : BlockTags.m_13115_().m_5643_().entrySet())
+		for(Block element : ForgeRegistries.BLOCKS.tags().getTag(blockKey).stream().toList())
 		{
-			if(namedTag.getKey().toString().equals(tag))
+			try
 			{
-				for(Block element : namedTag.getValue().getValues())
-				{
-					try
-					{
-						results.add(element.getRegistryName().toString());
-					} catch(Exception e){ /* Failed, don't care */ };
-				}
-			}
+				results.add(element.getRegistryName().toString());
+			} catch(Exception e){ /* Failed, don't care */ };
 		}
 
-		for(Map.Entry<ResourceLocation, Tag<Fluid>> namedTag : FluidTags.m_144299_().m_5643_().entrySet())
+		for(Fluid element : ForgeRegistries.FLUIDS.tags().getTag(fluidKey).stream().toList())
 		{
-			if(namedTag.getKey().toString().equals(tag))
+			try
 			{
-				for(Fluid element : namedTag.getValue().getValues())
-				{
-					try
-					{
-						results.add(element.getRegistryName().toString());
-					} catch(Exception e){ /* Failed, don't care */ };
-				}
-			}
+				results.add(element.getRegistryName().toString());
+			} catch(Exception e){ /* Failed, don't care */ };
 		}
 
-		for(Map.Entry<ResourceLocation, Tag<EntityType<?>>> namedTag : EntityTypeTags.m_13126_().m_5643_().entrySet())
+		for(EntityType<?> element : ForgeRegistries.ENTITIES.tags().getTag(entityKey).stream().toList())
 		{
-			if(namedTag.getKey().toString().equals(tag))
+			try
 			{
-				for(EntityType<?> element : namedTag.getValue().getValues())
-				{
-					try
-					{
-						results.add(element.getRegistryName().toString());
-					} catch(Exception e){ /* Failed, don't care */ };
-				}
-			}
+				results.add(element.getRegistryName().toString());
+			} catch(Exception e){ /* Failed, don't care */ };
 		}
 
 		return results;
@@ -1212,7 +1193,7 @@ public class XP
 		Map<String, Double> biomeBoosts = new HashMap<>();
 		double biomePenaltyMultiplier = Config.getConfig("biomePenaltyMultiplier");
 
-		Biome biome = player.level.getBiomeManager().m_47881_(vecToBlock(player.position()));
+		Biome biome = player.level.getBiome(vecToBlock(player.position())).value();
 		ResourceLocation resLoc = biome.getRegistryName();
 		if(resLoc == null)
 			return new HashMap<>();
@@ -1703,7 +1684,7 @@ public class XP
 
 	public static void checkBiomeLevelReq(Player player)
 	{
-		Biome biome = player.level.getBiomeManager().m_47881_(vecToBlock(player.position()));
+		Biome biome = player.level.getBiome(vecToBlock(player.position())).value();
 		ResourceLocation resLoc = XP.getBiomeResLoc(player.level, biome);
 		if(resLoc == null)
 			return;

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -1,5 +1,5 @@
 modLoader="javafml"
-loaderVersion="[39,)"
+loaderVersion="[40,)"
 license="All rights reserved"
 
 [[mods]]
@@ -16,12 +16,12 @@ Adds many different skills and benefits thanks to the skills to the game!
 [[dependencies.pmmo]] #optional
     modId="forge" #mandatory
     mandatory=true #mandatory
-    versionRange="[39.0.53,)" #mandatory
+    versionRange="[40.0.0,)" #mandatory
     ordering="NONE"
     side="BOTH"
 [[dependencies.pmmo]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.18,1.19)"
+    versionRange="[1.18.2,1.19)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
This PR updates PMMO to the post 40.0.18 changes.  Version 40.0.18 of forge introduced the TagManager which resolved the issue of biome tags that were not captured in the API, but present in Minecraft.  Previous versions of forge did not alter the tag mechanics.  As such this version of PMMO is incompatible with forge versions lower than 40.0.18.

Extras:
- Fixed Night Vision being broken when the perk was used.  